### PR TITLE
Update mcMMO dependency & allow multipliers < 1.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -218,7 +218,7 @@
         <dependency>
             <groupId>com.gmail.nossr50.mcMMO</groupId>
             <artifactId>mcMMO</artifactId>
-            <version>2.2.041</version>
+            <version>2.2.044-SNAPSHOT</version>
             <scope>provided</scope>
             <exclusions>
                 <exclusion>

--- a/src/main/java/fr/ax_dev/universejobs/integration/McMMOHandler.java
+++ b/src/main/java/fr/ax_dev/universejobs/integration/McMMOHandler.java
@@ -105,7 +105,7 @@ public class McMMOHandler {
             return 1.0;
         }
 
-        double multiplier = 1.0;
+        double multiplier = 0.0;
 
         for (Map.Entry<String, McMMOAbilityConfig> entry : mcmmoConfig.entrySet()) {
             McMMOAbilityConfig config = entry.getValue();


### PR DESCRIPTION
# Adds support for mcMMO ability multipliers below 1.0

## Details
This simple PR was requested by a client. It updates the mcMMO system to allow ability multipliers to be less than 1.0 (e.g., 0.1), enabling finer-grained control over ability scaling and balancing.

## Impact
- Supports fractional multipliers for more nuanced gameplay adjustments