### PR TITLE
Add SelectJobPlaceholder, job prefix and suffix

### DIFF
--- a/src/main/java/fr/ax_dev/universejobs/action/ActionProcessor.java
+++ b/src/main/java/fr/ax_dev/universejobs/action/ActionProcessor.java
@@ -910,7 +910,9 @@ public class ActionProcessor {
         String message = plugin.getConfig().getString("messages.level-up", 
                 "&aCongratulations! You reached level {level} in {job}!")
                 .replace("{level}", String.valueOf(newLevel))
-                .replace("{job}", job.getName());
+                .replace("{job}", job.getName())
+                .replace("{prefix}", job.getPrefix())
+                .replace("{suffix}", job.getSuffix());
         
         MessageUtils.sendMessage(player, message);
         

--- a/src/main/java/fr/ax_dev/universejobs/command/handler/AdminJobCommandHandler.java
+++ b/src/main/java/fr/ax_dev/universejobs/command/handler/AdminJobCommandHandler.java
@@ -298,7 +298,10 @@ public class AdminJobCommandHandler extends JobCommandHandler {
                         
                         // Send XP message to player with final values
                         String messageText = job.getXpMessageSettings().processMessage(finalValues[0], finalValues[1]);
-                        messageText = messageText.replace("{job}", job.getDisplayName());
+                        messageText = messageText
+                                .replace("{job}", job.getDisplayName())
+                                .replace("{prefix}", job.getPrefix())
+                                .replace("{suffix}", job.getSuffix());
                         
                         plugin.getMessageSender().sendXpMessage(onlinePlayer, job, finalValues[0], finalValues[1], playerData);
                     }

--- a/src/main/java/fr/ax_dev/universejobs/job/Job.java
+++ b/src/main/java/fr/ax_dev/universejobs/job/Job.java
@@ -18,6 +18,8 @@ public class Job {
     
     private final String id;
     private final String name;
+    private final String prefix;
+    private final String suffix;
     private final List<String> description;
     private final List<String> lore;
     private final String permission;
@@ -48,6 +50,8 @@ public class Job {
         this.id = id;
         this.config = config; // Store the config reference
         this.name = config.getString("name", id);
+        this.prefix = config.getString("prefix", "");
+        this.suffix = config.getString("suffix", "");
         // Handle both string and list descriptions
         if (config.isList("description")) {
             this.description = config.getStringList("description");
@@ -179,7 +183,15 @@ public class Job {
     public String getName() {
         return name;
     }
-    
+
+    public String getPrefix() {
+        return prefix;
+    }
+
+    public String getSuffix() {
+        return suffix;
+    }
+
     /**
      * Get the description of this job.
      * 

--- a/src/main/java/fr/ax_dev/universejobs/levelup/SimpleLevelUpActionManager.java
+++ b/src/main/java/fr/ax_dev/universejobs/levelup/SimpleLevelUpActionManager.java
@@ -321,11 +321,13 @@ public class SimpleLevelUpActionManager {
      */
     private String processPlaceholders(String text, Player player, Job job, int level, int oldLevel) {
         return text
-            .replace("{player}", player.getName())
-            .replace("{job}", job.getName())
-            .replace("{oldlevel}", String.valueOf(oldLevel))
-            .replace("{newlevel}", String.valueOf(level))
-            .replace("{level}", String.valueOf(level));
+                .replace("{player}", player.getName())
+                .replace("{job}", job.getName())
+                .replace("{prefix}", job.getPrefix())
+                .replace("{suffix}", job.getSuffix())
+                .replace("{oldlevel}", String.valueOf(oldLevel))
+                .replace("{newlevel}", String.valueOf(level))
+                .replace("{level}", String.valueOf(level));
     }
     
     /**

--- a/src/main/java/fr/ax_dev/universejobs/placeholder/SelectJobPlaceholder.java
+++ b/src/main/java/fr/ax_dev/universejobs/placeholder/SelectJobPlaceholder.java
@@ -1,0 +1,410 @@
+package fr.ax_dev.universejobs.placeholder;
+
+import fr.ax_dev.universejobs.UniverseJobs;
+import fr.ax_dev.universejobs.job.Job;
+import fr.ax_dev.universejobs.job.JobManager;
+import fr.ax_dev.universejobs.job.PlayerJobData;
+import org.bukkit.OfflinePlayer;
+
+import java.util.*;
+
+public class SelectJobPlaceholder {
+
+    private final UniverseJobs plugin;
+    private final JobManager jobManager;
+
+    public SelectJobPlaceholder(final UniverseJobs plugin) {
+        this.plugin = plugin;
+        this.jobManager = plugin.getJobManager();
+    }
+
+    public String onRequest(OfflinePlayer player, String params) {
+        if (player == null) return "";
+
+        PlayerJobData data;
+        try {
+            data = jobManager.getPlayerData(player.getUniqueId());
+        } catch (Exception e) {
+            return "";
+        }
+
+        if (data == null || data.isLoading()) {
+            return "";
+        }
+
+        String clean = params;
+
+        if (clean.startsWith("select_")) {
+            clean = clean.substring("select_".length());
+        }
+
+        Args args = Args.parse(clean);
+
+        List<JobContext> jobs = buildContexts(plugin, data);
+
+        // active filter
+        if (args.filterActive()) {
+            jobs.removeIf(j -> !j.isActive());
+        }
+
+        // apply sorters
+        applySorters(jobs, args);
+
+        // position required
+        if (!args.hasPosition()) {
+            return args.getDefaultValue();
+        }
+
+        int pos = args.getPosition();
+        if (pos < 1 || pos > jobs.size()) {
+            return args.getDefaultValue();
+        }
+
+        JobContext selected = jobs.get(pos - 1);
+        return JobValueResolver.resolve(selected, args);
+    }
+
+    private static List<JobContext> buildContexts(UniverseJobs plugin, PlayerJobData data) {
+        List<JobContext> list = new ArrayList<>();
+
+        for (Job job : plugin.getJobManager().getAllJobs()) {
+            list.add(new JobContext(job, data));
+        }
+
+        return list;
+    }
+
+    private static void applySorters(List<JobContext> jobs, Args args) {
+        Comparator<JobContext> comparator = null;
+
+        for (String raw : args.getSorters()) {
+            boolean desc = raw.endsWith("_desc") || raw.endsWith(":desc");
+
+            String key = raw
+                    .replace("_desc", "")
+                    .replace("_asc", "")
+                    .replace(":desc", "")
+                    .replace(":asc", "");
+
+            JobSorter sorter = SorterRegistry.get(key);
+            if (sorter == null) continue;
+
+            Comparator<JobContext> next = sorter.comparator(desc);
+
+            comparator = (comparator == null)
+                    ? next
+                    : comparator.thenComparing(next);
+        }
+
+        if (comparator != null) {
+            jobs.sort(comparator);
+        }
+    }
+
+    public static final class Args {
+
+        private final Map<String, String> raw;
+
+        private Args(Map<String, String> raw) {
+            this.raw = raw;
+        }
+
+        /* ---------- factory ---------- */
+
+        public static Args parse(String params) {
+            Map<String, String> map = new HashMap<>();
+
+            if (params == null || params.isBlank()) {
+                return new Args(map);
+            }
+
+            String[] parts = params.contains(";")
+                    ? params.split(";")
+                    : params.split("_");
+
+            for (String part : parts) {
+                if (part.isBlank()) continue;
+
+                int idx = part.indexOf('=');
+                if (idx <= 0 || idx == part.length() - 1) continue;
+
+                String key = part.substring(0, idx)
+                        .trim()
+                        .toLowerCase(Locale.ROOT);
+
+                String value = part.substring(idx + 1).trim();
+
+                if (key.isEmpty() || value.isEmpty()) continue;
+
+                map.put(key, value);
+            }
+
+            return new Args(map);
+        }
+
+        /* ---------- raw ---------- */
+
+        public boolean has(String key) {
+            return raw.containsKey(key.toLowerCase());
+        }
+
+        public String get(String key) {
+            return raw.get(key.toLowerCase());
+        }
+
+        /* ---------- typed ---------- */
+
+        public String getString(String key, String def) {
+            return raw.getOrDefault(key.toLowerCase(), def);
+        }
+
+        public int getInt(String key, int def) {
+            try {
+                return Integer.parseInt(raw.get(key.toLowerCase()));
+            } catch (Exception ignored) {
+                return def;
+            }
+        }
+
+        public boolean getBoolean(String key, boolean def) {
+            String v = raw.get(key.toLowerCase());
+            if (v == null) return def;
+            return v.equalsIgnoreCase("true") || v.equalsIgnoreCase("yes") || v.equals("1");
+        }
+
+        public List<String> getList(String key) {
+            String v = raw.get(key.toLowerCase());
+            if (v == null || v.isBlank()) return List.of();
+
+            return Arrays.stream(v.split(","))
+                    .map(String::trim)
+                    .filter(s -> !s.isEmpty())
+                    .toList();
+        }
+
+        /* ---------- semantic helpers ---------- */
+
+        public boolean hasPosition() {
+            return has("position");
+        }
+
+        public int getPosition() {
+            return getInt("position", -1);
+        }
+
+        public boolean filterActive() {
+            return getBoolean("active", false);
+        }
+
+        public String getDefaultValue() {
+            return getString("default", "");
+        }
+
+        public String getValueType() {
+            return getString("value", "name");
+        }
+
+        public List<String> getSorters() {
+            return getList("sort");
+        }
+    }
+
+    public record JobContext(
+            Job job,
+            PlayerJobData data
+    ) {
+
+        public String id() { return job.getId(); }
+        public String name() { return job.getName(); }
+        public String prefix() { return job.getPrefix(); }
+        public String suffix() { return job.getSuffix(); }
+
+        public boolean isActive() {
+            return job.isEnabled() && data.hasJob(job.getId());
+        }
+
+        public int level() { return data.getLevel(job.getId()); }
+        public double totalXp() { return data.getXp(job.getId()); }
+
+        public double[] xpProgress() { return data.getXpProgress(job.getId()); }
+        public double xpInLevel() { return xpProgress()[0]; }
+        public double xpToNext() { return xpProgress()[1]; }
+
+        public boolean isMaxLevel() {
+            return level() >= data.getMaxLevel(job.getId());
+        }
+
+        public int maxLevel() { return data.getMaxLevel(job.getId()); }
+        public boolean hasXpCurve() { return job.getXpCurve() != null; }
+    }
+
+    public interface JobSorter {
+        Comparator<JobContext> comparator(boolean descending);
+    }
+
+    public static class LevelSorter implements JobSorter {
+        @Override
+        public Comparator<JobContext> comparator(boolean desc) {
+            Comparator<JobContext> c = Comparator.comparingInt(JobContext::level);
+            return desc ? c.reversed() : c;
+        }
+    }
+
+    public static class XpSorter implements JobSorter {
+        @Override
+        public Comparator<JobContext> comparator(boolean desc) {
+            Comparator<JobContext> c = Comparator.comparingDouble(JobContext::totalXp);
+            return desc ? c.reversed() : c;
+        }
+    }
+
+    public static class NameSorter implements JobSorter {
+        @Override
+        public Comparator<JobContext> comparator(boolean desc) {
+            Comparator<JobContext> c = Comparator.comparing(JobContext::name, String.CASE_INSENSITIVE_ORDER);
+            return desc ? c.reversed() : c;
+        }
+    }
+
+    public static class XpPercentSorter implements JobSorter {
+
+        @Override
+        public Comparator<JobContext> comparator(boolean desc) {
+            Comparator<JobContext> c = Comparator.comparingDouble(this::progress);
+            return desc ? c.reversed() : c;
+        }
+
+        private double progress(JobContext ctx) {
+            if (ctx.isMaxLevel()) return 1.0;
+
+            double in = ctx.xpInLevel();
+            double toNext = ctx.xpToNext();
+
+            if (toNext <= 0) return 1.0;
+            return in / (in + toNext);
+        }
+    }
+
+    public static class ActiveSorter implements JobSorter {
+        @Override
+        public Comparator<JobContext> comparator(boolean desc) {
+            Comparator<JobContext> c = Comparator.comparing(JobContext::isActive);
+            return desc ? c.reversed() : c;
+        }
+    }
+
+    public static class MaxLevelSorter implements JobSorter {
+        @Override
+        public Comparator<JobContext> comparator(boolean desc) {
+            Comparator<JobContext> c = Comparator.comparing(JobContext::isMaxLevel);
+            return desc ? c.reversed() : c;
+        }
+    }
+
+    public static class IdSorter implements JobSorter {
+        @Override
+        public Comparator<JobContext> comparator(boolean desc) {
+            Comparator<JobContext> c = Comparator.comparing(JobContext::id, String.CASE_INSENSITIVE_ORDER);
+            return desc ? c.reversed() : c;
+        }
+    }
+
+    public static class SorterRegistry {
+
+        private static final Map<String, JobSorter> SORTERS = new HashMap<>();
+        private static final Map<String, String> ALIASES = new HashMap<>();
+
+        static {
+            register("level", new LevelSorter(), "lvl");
+            register("xp", new XpSorter(), "experience");
+            register("xp_percent", new XpPercentSorter(),
+                    "percent", "progress", "xp_progress");
+            register("name", new NameSorter(), "jobname");
+            register("active", new ActiveSorter(), "enabled");
+            register("maxlevel", new MaxLevelSorter(), "cap");
+            register("id", new IdSorter());
+        }
+
+        private static void register(String key, JobSorter sorter, String... aliases) {
+            SORTERS.put(key, sorter);
+            ALIASES.put(key, key);
+
+            for (String alias : aliases) {
+                ALIASES.put(alias.toLowerCase(), key);
+            }
+        }
+
+        public static JobSorter get(String key) {
+            if (key == null) return null;
+
+            String normalized = ALIASES.get(key.toLowerCase());
+            if (normalized == null) return null;
+
+            return SORTERS.get(normalized);
+        }
+    }
+
+    public enum ValueKey {
+        ID,
+        NAME,
+        PREFIX,
+        SUFFIX,
+        LEVEL,
+        MAXLEVEL,
+        XP,
+        XP_IN_LEVEL,
+        XP_TO_NEXT,
+        XP_PERCENT
+    }
+
+    public static final class JobValueResolver {
+
+        private static final Map<String, ValueKey> VALUES = new HashMap<>();
+
+        static {
+            register(ValueKey.ID, "id");
+            register(ValueKey.NAME, "name");
+            register(ValueKey.PREFIX, "prefix");
+            register(ValueKey.SUFFIX, "suffix");
+            register(ValueKey.LEVEL, "level", "lvl");
+            register(ValueKey.MAXLEVEL, "maxlevel", "cap");
+            register(ValueKey.XP, "xp", "experience");
+            register(ValueKey.XP_IN_LEVEL, "xpinlevel", "currentxp");
+            register(ValueKey.XP_TO_NEXT, "xptonext", "remainingxp");
+            register(ValueKey.XP_PERCENT, "progress", "percent", "xp_percent");
+        }
+
+        private static void register(ValueKey key, String... names) {
+            for (String name : names) {
+                VALUES.put(name.toLowerCase(), key);
+            }
+        }
+
+        public static String resolve(JobContext job, Args args) {
+            ValueKey key = VALUES.get(args.getValueType().toLowerCase());
+            if (key == null) {
+                return args.getDefaultValue();
+            }
+
+            return switch (key) {
+                case ID -> job.id();
+                case NAME -> job.name();
+                case PREFIX -> job.prefix();
+                case SUFFIX -> job.suffix();
+                case LEVEL -> String.valueOf(job.level());
+                case MAXLEVEL -> String.valueOf(job.maxLevel());
+                case XP -> String.valueOf((long) job.totalXp());
+                case XP_IN_LEVEL -> String.valueOf((long) job.xpInLevel());
+                case XP_TO_NEXT -> String.valueOf((long) job.xpToNext());
+                case XP_PERCENT -> {
+                    if (job.isMaxLevel()) yield "100";
+                    double in = job.xpInLevel();
+                    double toNext = job.xpToNext();
+                    if (toNext <= 0) yield "100";
+                    yield String.format("%.2f", (in / (in + toNext)) * 100);
+                }
+            };
+        }
+    }
+
+}

--- a/src/main/java/fr/ax_dev/universejobs/placeholder/UniversalPlaceholderExpansion.java
+++ b/src/main/java/fr/ax_dev/universejobs/placeholder/UniversalPlaceholderExpansion.java
@@ -7,12 +7,14 @@ import org.bukkit.OfflinePlayer;
 public class UniversalPlaceholderExpansion extends PlaceholderExpansion {
 
     private final UniverseJobs plugin;
+    private final SelectJobPlaceholder selectJobPlaceholder;
     private final JobsLeaderboardPlaceholder jobsLeaderboardPlaceholder;
     private final GlobalLeaderboardPlaceholder globalLeaderboardPlaceholder;
     private final BoostPlaceholder boostPlaceholder;
 
     public UniversalPlaceholderExpansion(UniverseJobs plugin) {
         this.plugin = plugin;
+        this.selectJobPlaceholder = new SelectJobPlaceholder(plugin);
         this.jobsLeaderboardPlaceholder = new JobsLeaderboardPlaceholder(plugin);
         this.globalLeaderboardPlaceholder = new GlobalLeaderboardPlaceholder(plugin);
         this.boostPlaceholder = new BoostPlaceholder(plugin);
@@ -59,6 +61,10 @@ public class UniversalPlaceholderExpansion extends PlaceholderExpansion {
         String[] args = params.split("_");
         if (args.length < 1) return null;
 
+        if (args[0].equalsIgnoreCase("select")) {
+            return selectJobPlaceholder.onRequest(player, params);
+        }
+
         if (args[0].equalsIgnoreCase("global")) {
             return globalLeaderboardPlaceholder.onRequest(player, params);
         }
@@ -95,6 +101,12 @@ public class UniversalPlaceholderExpansion extends PlaceholderExpansion {
                 }
                 if (args.length == 3 && args[2].equalsIgnoreCase("id")) {
                     return jobId;
+                }
+                if (args.length == 3 && args[2].equalsIgnoreCase("prefix")) {
+                    return job.getPrefix();
+                }
+                if (args.length == 3 && args[2].equalsIgnoreCase("suffix")) {
+                    return job.getSuffix();
                 }
             } catch (NumberFormatException e) {
                 return "";

--- a/src/main/java/fr/ax_dev/universejobs/reward/RewardManager.java
+++ b/src/main/java/fr/ax_dev/universejobs/reward/RewardManager.java
@@ -354,10 +354,11 @@ public class RewardManager {
         // Execute commands
         if (reward.hasCommands()) {
             for (String command : reward.getCommands()) {
-                String processedCommand = command.replace("{player}", player.getName())
-                                                .replace("{job}", reward.getJobId())
-                                                .replace("{reward}", reward.getId())
-                                                .replace("%player_name%", player.getName());
+                String processedCommand = command
+                        .replace("{player}", player.getName())
+                        .replace("{job}", reward.getJobId())
+                        .replace("{reward}", reward.getId())
+                        .replace("%player_name%", player.getName());
                 
                 // Process PlaceholderAPI placeholders
                 processedCommand = MenuUtils.processPlaceholders(player, processedCommand);

--- a/src/main/java/fr/ax_dev/universejobs/reward/gui/CustomRewardGui.java
+++ b/src/main/java/fr/ax_dev/universejobs/reward/gui/CustomRewardGui.java
@@ -67,7 +67,10 @@ public class CustomRewardGui implements InventoryHolder {
      * Create the inventory with the configured size and title.
      */
     private void createInventory() {
-        String title = config.getTitle().replace("{job}", job.getName());
+        String title = config.getTitle()
+                .replace("{job}", job.getName())
+                .replace("{prefix}", job.getPrefix())
+                .replace("{suffix}", job.getSuffix());
         title = MenuUtils.processPlaceholders(player, title);
         this.inventory = Bukkit.createInventory(this, config.getSize(), MessageUtils.colorize(title));
     }

--- a/src/main/java/fr/ax_dev/universejobs/reward/gui/RewardGuiManager.java
+++ b/src/main/java/fr/ax_dev/universejobs/reward/gui/RewardGuiManager.java
@@ -198,7 +198,10 @@ public class RewardGuiManager implements Listener {
             this.rewardsPerPage = config.getRewardsPerPage();
             this.guiSize = config.getSize();
             
-            String title = config.getTitleFormat().replace("{job}", job.getName());
+            String title = config.getTitleFormat()
+                    .replace("{job}", job.getName())
+                    .replace("{prefix}", job.getPrefix())
+                    .replace("{suffix}", job.getSuffix());
             title = MenuUtils.processPlaceholders(player, title);
             this.inventory = Bukkit.createInventory(this, guiSize, MessageUtils.colorize(title));
             
@@ -442,19 +445,25 @@ public class RewardGuiManager implements Listener {
                 List<String> loreLines = config.getNavigationLore(type);
                 
                 // Replace placeholders in name
-                name = name.replace("{current_page}", String.valueOf(page + 1))
-                          .replace("{total_pages}", String.valueOf(totalPages))
-                          .replace("{target_page}", String.valueOf(targetPage))
-                          .replace("{job}", job.getName());
+                name = name
+                        .replace("{current_page}", String.valueOf(page + 1))
+                        .replace("{total_pages}", String.valueOf(totalPages))
+                        .replace("{target_page}", String.valueOf(targetPage))
+                        .replace("{job}", job.getName())
+                        .replace("{prefix}", job.getPrefix())
+                        .replace("{suffix}", job.getSuffix());
                 name = MenuUtils.processPlaceholders(player, name);
                 
                 // Replace placeholders in lore
                 List<String> processedLore = new ArrayList<>();
                 for (String loreLine : loreLines) {
-                    String processed = loreLine.replace("{current_page}", String.valueOf(page + 1))
-                                              .replace("{total_pages}", String.valueOf(totalPages))
-                                              .replace("{target_page}", String.valueOf(targetPage))
-                                              .replace("{job}", job.getName());
+                    String processed = loreLine
+                            .replace("{current_page}", String.valueOf(page + 1))
+                            .replace("{total_pages}", String.valueOf(totalPages))
+                            .replace("{target_page}", String.valueOf(targetPage))
+                            .replace("{job}", job.getName())
+                            .replace("{prefix}", job.getPrefix())
+                            .replace("{suffix}", job.getSuffix());
                     processedLore.add(MenuUtils.processPlaceholders(player, processed));
                 }
                 

--- a/src/main/java/fr/ax_dev/universejobs/utils/AsyncXpMessageSender.java
+++ b/src/main/java/fr/ax_dev/universejobs/utils/AsyncXpMessageSender.java
@@ -100,6 +100,8 @@ public class AsyncXpMessageSender {
         // Build message once with all placeholders
         String message = settings.processMessage(displayXp, displayMoney)
                 .replace("{job}", job.getName())
+                .replace("{prefix}", job.getPrefix())
+                .replace("{suffix}", job.getSuffix())
                 .replace("{level}", String.valueOf(currentLevel))
                 .replace("{max_level}", String.valueOf(playerData.getMaxLevel(job.getId())))
                 .replace("{progress}", String.format("%.1f", progressPercent))


### PR DESCRIPTION
- add a new placeholder that selects a job value from a player job list which can be sorted, filtered, and selected by position
- add job prefix and suffix, for practicality (to separate colors, maybe job symbols, etc)

## Description

This introduces a new select-style placeholder that allows retrieving a specific job-related value from a player’s job list.
The placeholder supports filtering, multi-criteria sorting, and position-based selection, making it suitable for dynamic displays such as scoreboards, GUIs, and chat formats.

Also, job prefix and suffix values are exposed for convenience, for better formatting (e.g. colors, symbols, or separators).

The implementation does not modify existing placeholders.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [x] Enhancement/Improvement
- [ ] Documentation
- [ ] Refactoring
- [ ] Other (describe below)

## Related Issues

This PR is not related to any known bug or issue

## Checklist

- [x] My code follows the project's coding style
- [x] I have tested my changes locally
- [ ] I have updated the documentation if needed
- [x] My changes don't break existing functionality

## Testing

I compiled the code using 'mvn package' and tried it locally (MC Paper version 1.21.10-117-ver/1.21.10@df4b668). The selector placeholder works as intended after testing its syntax. No errors show up in console when the placeholder is used, regardless of whether it finds a value.

## Screenshots (if applicable)

There are no GUI changes in this PR
